### PR TITLE
added copyIdButton to showAnnotation

### DIFF
--- a/hlib.ts
+++ b/hlib.ts
@@ -947,7 +947,7 @@ export function csvRow(level: number, anno: any): string {
 }
 
 /** Render an annotation card. */
-export function showAnnotation(anno: annotation, level: number, tagUrlPrefix?: string, externalLink?: string) {
+export function showAnnotation(anno: annotation, level: number, tagUrlPrefix?: string, externalLink?: string, copyIdButton?: string) {
 
   function getGroupName(anno:any):any {
     let groupName = anno.group
@@ -988,6 +988,9 @@ export function showAnnotation(anno: annotation, level: number, tagUrlPrefix?: s
       <img class="externalLinkImage" src="https://jonudell.info/hlib/externalLink.png">
     </a>`
  
+  const _copyIdButton = copyIdButton ? copyIdButton : `
+    <button onclick="(function(){navigator.clipboard.writeText('${anno.id}')})();">${anno.id}</button>`
+
   const marginLeft = level * 20
 
   const groupName = getGroupName(anno)
@@ -1017,6 +1020,8 @@ export function showAnnotation(anno: annotation, level: number, tagUrlPrefix?: s
         <span class="groupSlug">${groupSlug}</span>
         <span>&nbsp;</span>
         <span class="externalLink">${_externalLink}</span>
+        <span>&nbsp;</span>
+        <span class="copyIdButton">${_copyIdButton}</span>
       </div>
       <div class="annotationQuote">${anno.quote}</div>
       <div class="annotationBody">


### PR DESCRIPTION
While debugging a set of bad annos today I needed to collect a subset
of their identifiers to enter into a script. This button serves a dual
role of making the annotation id visible and making making it possible
to copy the id to the clipboard with a single click. The value can be
passed in as a parameter so the share link, direct link, etc could be
copied rather than the raw id, depending on what a workflow calls for.